### PR TITLE
Fix unused deviceId parameter in AlbumPlayButton

### DIFF
--- a/frontend/src/features/band/BandPage.tsx
+++ b/frontend/src/features/band/BandPage.tsx
@@ -86,7 +86,6 @@ export function BandPage() {
                           albumName={album.name}
                           bandName={band.name}
                           accessToken={accessToken}
-                          deviceId={deviceId}
                         />
                       )}
                       <Link
@@ -133,11 +132,10 @@ export function BandPage() {
   );
 }
 
-function AlbumPlayButton({ albumName, bandName, accessToken, deviceId }: {
+function AlbumPlayButton({ albumName, bandName, accessToken }: {
   albumName: string;
   bandName: string;
   accessToken: string;
-  deviceId: string;
 }) {
   const [status, setStatus] = useState<'idle' | 'loading' | 'failed'>('idle');
 


### PR DESCRIPTION
## Summary
- Remove unused `deviceId` prop from `AlbumPlayButton` component
- Fixes TypeScript build error (`TS6133: 'deviceId' is declared but its value is never read`)

## Test plan
- [x] Verify Docker build succeeds (this was blocking CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)