### PR TITLE
Add network isolation and pin image versions

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16.6-alpine3.21
     environment:
       POSTGRES_DB: metaloreian
       POSTGRES_USER: metaloreian
@@ -13,6 +13,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    networks:
+      - db
     restart: unless-stopped
 
   backend:
@@ -32,10 +34,13 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    networks:
+      - db
+      - web
     restart: unless-stopped
 
   nginx:
-    image: nginx:alpine
+    image: nginx:1.27-alpine
     ports:
       - "80:80"
       - "443:443"
@@ -45,14 +50,22 @@ services:
       - certbot-certs:/etc/letsencrypt:ro
     depends_on:
       - backend
+    networks:
+      - web
     restart: unless-stopped
 
   certbot:
-    image: certbot/certbot
+    image: certbot/certbot:v3.3.0
     volumes:
       - certbot-webroot:/var/www/certbot
       - certbot-certs:/etc/letsencrypt
+    networks:
+      - web
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done'"
+
+networks:
+  db:
+  web:
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- Add separate `db` and `web` Docker networks — nginx can only reach backend, not postgres
- Pin mutable image tags: `postgres:16.6-alpine3.21`, `nginx:1.27-alpine`, `certbot/certbot:v3.3.0`

## Test plan
- [x] Verify containers start and can communicate correctly
- [x] Verify nginx cannot reach postgres (`docker exec nginx ping postgres` should fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)