### PR TITLE
Fix backend healthcheck HEAD vs GET

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
       PORT: "8080"
     shm_size: 256m
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "-O", "/dev/null", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- The `--spider` flag in wget sends HEAD requests, but the backend returns 405 Method Not Allowed on HEAD `/health`
- Replaced `--spider` with `-O /dev/null` to send GET requests and discard the response body
- This fixes the backend showing as `unhealthy` in Docker despite being operational

## Test plan
- [x] Verify CI/CD deploys successfully
- [x] Confirm backend container shows as `healthy` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)