### PR TITLE
Switch to HTTPS with DuckDNS DNS-01 challenge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,11 +87,12 @@ jobs:
           VM_HOST: ${{ secrets.VM_HOST }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          DUCKDNS_TOKEN: ${{ secrets.DUCKDNS_TOKEN }}
         run: |
           SSH="ssh ${SSH_OPTS} -i ~/.ssh/deploy_key ${VM_USER}@${VM_HOST}"
           ${SSH} "mkdir -p ~/metaloreian/backend/migrations"
-          printf 'POSTGRES_PASSWORD=%s\nSPOTIFY_CLIENT_ID=%s\nFRONTEND_URL=https://metaloreian.is-a.dev\n' \
-            "${POSTGRES_PASSWORD}" "${SPOTIFY_CLIENT_ID}" | \
+          printf 'POSTGRES_PASSWORD=%s\nSPOTIFY_CLIENT_ID=%s\nFRONTEND_URL=https://metaloreian.duckdns.org\nDUCKDNS_TOKEN=%s\n' \
+            "${POSTGRES_PASSWORD}" "${SPOTIFY_CLIENT_ID}" "${DUCKDNS_TOKEN}" | \
             ${SSH} "umask 077 && cat > ~/metaloreian/.env"
 
       - name: Deploy containers on VM

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
     environment:
       DATABASE_URL: postgres://metaloreian:${POSTGRES_PASSWORD}@postgres:5432/metaloreian?sslmode=disable
       SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:?Set SPOTIFY_CLIENT_ID in .env}
-      FRONTEND_URL: ${FRONTEND_URL:-https://metaloreian.is-a.dev}
+      FRONTEND_URL: ${FRONTEND_URL:-https://metaloreian.duckdns.org}
       PORT: "8080"
     shm_size: 256m
     healthcheck:
@@ -46,7 +46,6 @@ services:
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - certbot-webroot:/var/www/certbot:ro
       - certbot-certs:/etc/letsencrypt:ro
     depends_on:
       - backend
@@ -55,13 +54,13 @@ services:
     restart: unless-stopped
 
   certbot:
-    image: certbot/certbot:v3.3.0
+    image: infinityofspace/certbot_dns_duckdns:v1.8.0@sha256:b0af09403424eef05a3f2d2421c32f123acbef45e0a0fe969895c2e58390dc43
+    environment:
+      DUCKDNS_TOKEN: ${DUCKDNS_TOKEN:?Set DUCKDNS_TOKEN in .env}
     volumes:
-      - certbot-webroot:/var/www/certbot
       - certbot-certs:/etc/letsencrypt
-    networks:
-      - web
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done'"
+    networks: []
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --dns-duckdns; sleep 12h & wait $${!}; done'"
 
 networks:
   db:
@@ -69,5 +68,4 @@ networks:
 
 volumes:
   pgdata:
-  certbot-webroot:
   certbot-certs:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,13 +1,7 @@
 server {
     listen 80;
-    server_name metaloreian.is-a.dev;
+    server_name metaloreian.duckdns.org;
 
-    # Let's Encrypt ACME challenge
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
-
-    # Redirect everything else to HTTPS
     location / {
         return 301 https://$host$request_uri;
     }
@@ -15,10 +9,17 @@ server {
 
 server {
     listen 443 ssl;
-    server_name metaloreian.is-a.dev;
+    server_name metaloreian.duckdns.org;
 
-    ssl_certificate /etc/letsencrypt/live/metaloreian.is-a.dev/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/metaloreian.is-a.dev/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/metaloreian.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/metaloreian.duckdns.org/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
 
     # Security headers
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
- Replace certbot HTTP-01 with infinityofspace/certbot_dns_duckdns for DNS-01 validation (image pinned by digest)
- Update domain to metaloreian.duckdns.org throughout
- Add SSL hardening (TLS 1.2+, strong ciphers, no session tickets)
- Token read from env natively (not passed on CLI)
- Remove unused certbot-webroot volume
- Pass DUCKDNS_TOKEN through deploy workflow to VM .env