### PR TITLE
Fix certbot renew ambiguous flag

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
     volumes:
       - certbot-certs:/etc/letsencrypt
     networks: []
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --dns-duckdns; sleep 12h & wait $${!}; done'"
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done'"
 
 networks:
   db:


### PR DESCRIPTION
## Summary
- Remove `--dns-duckdns` from certbot renew entrypoint — it causes an ambiguous option error
- `certbot renew` uses saved authenticator config from the initial `certonly`, so the flag is unnecessary

## Test plan
- [x] CI/CD deploys successfully
- [x] Certbot container stays running without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)