### PR TITLE
Migrate deployment from Oracle Cloud to AWS EC2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           scp ${SSH_OPTS} -i ~/.ssh/deploy_key -r \
             docker-compose.prod.yml nginx.conf backend/migrations \
-            "${VM_USER}@${VM_HOST}:~/metaloreian/"
+            "${VM_USER}@${VM_HOST}:~/app/"
 
       - name: Write .env to VM
         env:
@@ -88,12 +88,13 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           DUCKDNS_TOKEN: ${{ secrets.DUCKDNS_TOKEN }}
+          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
         run: |
           SSH="ssh ${SSH_OPTS} -i ~/.ssh/deploy_key ${VM_USER}@${VM_HOST}"
-          ${SSH} "mkdir -p ~/metaloreian/backend/migrations"
-          printf 'POSTGRES_PASSWORD=%s\nSPOTIFY_CLIENT_ID=%s\nFRONTEND_URL=https://metaloreian.duckdns.org\nDUCKDNS_TOKEN=%s\n' \
-            "${POSTGRES_PASSWORD}" "${SPOTIFY_CLIENT_ID}" "${DUCKDNS_TOKEN}" | \
-            ${SSH} "umask 077 && cat > ~/metaloreian/.env"
+          ${SSH} "mkdir -p ~/app/backend/migrations"
+          printf 'POSTGRES_PASSWORD=%s\nSPOTIFY_CLIENT_ID=%s\nFRONTEND_URL=%s\nDUCKDNS_TOKEN=%s\n' \
+            "${POSTGRES_PASSWORD}" "${SPOTIFY_CLIENT_ID}" "${FRONTEND_URL}" "${DUCKDNS_TOKEN}" | \
+            ${SSH} "umask 077 && cat > ~/app/.env"
 
       - name: Deploy containers on VM
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Claude Code
+CLAUDE.local.md

--- a/README.md
+++ b/README.md
@@ -127,24 +127,24 @@ GET  /health                       Health check
 
 ## Production deployment
 
-The app deploys to an Oracle Cloud Always Free ARM VM with automated CI/CD via GitHub Actions. HTTPS is provided by Let's Encrypt via a free [is-a.dev](https://is-a.dev/) subdomain.
+The app deploys to an AWS EC2 t3.small instance (2 vCPU, 2GB RAM) with automated CI/CD via GitHub Actions. HTTPS is provided by Let's Encrypt via DNS-01 challenge with [DuckDNS](https://www.duckdns.org/).
 
 ### Architecture
 
 ```
-GitHub push → GitHub Actions → Build ARM64 image → Push to GHCR → SSH deploy to VM
+GitHub push → GitHub Actions → Build amd64 image → Push to GHCR → SSH deploy to VM
 
-VM:
-  nginx (80/443) → backend:8080 (Go + frontend static files)
-                    postgres:5432 (internal only)
-  certbot (auto-renews Let's Encrypt certs)
+EC2 t3.small (2GB RAM):
+  nginx (80/443)  → backend:8080 (Go + Chromium + frontend static)
+                     postgres:5432 (internal only)
+  certbot (DNS-01 via DuckDNS)
 ```
 
 ### Prerequisites
 
-- Oracle Cloud Always Free ARM A1.Flex VM (Ubuntu)
-- Domain: `metaloreian.is-a.dev` (A record → VM IP)
-- Spotify Developer Dashboard: `https://metaloreian.is-a.dev/callback` as redirect URI
+- AWS EC2 t3.small instance (Ubuntu 22.04)
+- Domain: `metaloreian-dev.duckdns.org` (DuckDNS → Elastic IP)
+- Spotify Developer Dashboard: `https://metaloreian-dev.duckdns.org/callback` as redirect URI
 
 ### VM initial setup (one-time)
 
@@ -154,70 +154,62 @@ curl -fsSL https://get.docker.com | sudo sh
 sudo usermod -aG docker $USER
 # Log out and back in for group change to take effect
 
-# 2. Open firewall (iptables + Oracle VCN Security List for 80/443)
-sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 80 -j ACCEPT
-sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 443 -j ACCEPT
-sudo netfilter-persistent save
+# 2. Create deploy user
+sudo useradd -m -s /bin/bash metaloreian
+sudo usermod -aG docker metaloreian
 
-# 3. Generate deploy SSH key
-ssh-keygen -t ed25519 -f ~/.ssh/deploy_key -N ""
-cat ~/.ssh/deploy_key.pub >> ~/.ssh/authorized_keys
-# Add the private key (~/.ssh/deploy_key) as GitHub secret VM_SSH_KEY
+# 3. Configure firewall
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
 
-# 4. Clone repo
-git clone https://github.com/ipurusho/metaloreian.git ~/metaloreian
-cd ~/metaloreian
+# 4. Security hardening
+sudo apt-get install -y fail2ban unattended-upgrades
 
-# 5. Create .env
-cat > .env << 'EOF'
-SPOTIFY_CLIENT_ID=your_spotify_client_id
-POSTGRES_PASSWORD=a_strong_password
-FRONTEND_URL=https://metaloreian.is-a.dev
-EOF
+# 5. Set up SSH for deploy user
+sudo -u metaloreian bash -c '
+  mkdir -p ~/.ssh && chmod 700 ~/.ssh
+'
+# Copy authorized_keys to deploy user
 
-# 6. Initial deploy
-docker compose -f docker-compose.prod.yml up -d
+# 6. Create app directory
+sudo -u metaloreian mkdir -p ~/app
 
-# 7. Obtain SSL certificate
-docker compose -f docker-compose.prod.yml run --rm certbot certonly \
-  --webroot -w /var/www/certbot -d metaloreian.is-a.dev
+# 7. Initial deploy (triggered by GitHub Actions push to main)
 
-# 8. Reload nginx to pick up the real cert
-docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
+# 8. Obtain SSL certificate (DNS-01 via DuckDNS)
+sudo -u metaloreian bash -c 'cd ~/app && \
+  docker compose -f docker-compose.prod.yml run --rm certbot certonly \
+    --authenticator dns-duckdns \
+    --dns-duckdns-token $DUCKDNS_TOKEN \
+    --dns-duckdns-propagation-seconds 60 \
+    -d metaloreian-dev.duckdns.org --agree-tos -m your@email.com'
+
+# 9. Reload nginx to pick up the real cert
+sudo -u metaloreian bash -c 'cd ~/app && docker compose -f docker-compose.prod.yml exec nginx nginx -s reload'
 ```
-
-### is-a.dev domain registration
-
-Fork [is-a-dev/register](https://github.com/is-a-dev/register), create `domains/metaloreian.json`:
-
-```json
-{
-  "owner": {
-    "username": "ipurusho"
-  },
-  "record": {
-    "A": ["<VM_PUBLIC_IP>"]
-  }
-}
-```
-
-Open a PR — typically merges within hours.
 
 ### GitHub secrets
 
 | Secret | Value |
 |--------|-------|
-| `VM_HOST` | Oracle VM public IP |
-| `VM_USER` | `ubuntu` |
+| `VM_HOST` | EC2 Elastic IP |
+| `VM_USER` | `metaloreian` |
 | `VM_SSH_KEY` | Deploy key (ed25519 private key) |
+| `VM_SSH_KNOWN_HOSTS` | Output of `ssh-keyscan -H <elastic-ip>` |
+| `POSTGRES_PASSWORD` | PostgreSQL password |
+| `SPOTIFY_CLIENT_ID` | Spotify Client ID (runtime) |
+| `DUCKDNS_TOKEN` | DuckDNS token for DNS-01 cert renewal |
+| `FRONTEND_URL` | `https://metaloreian-dev.duckdns.org` |
 | `VITE_SPOTIFY_CLIENT_ID` | Spotify Client ID (baked into frontend at build time) |
 
 ### CI/CD workflow
 
 On every push to `main`, GitHub Actions:
-1. Builds an ARM64 Docker image (QEMU cross-compilation)
+1. Builds an amd64 Docker image
 2. Pushes to `ghcr.io/ipurusho/metaloreian:latest` and `:<sha>`
-3. SSHs into the VM, pulls the new image, and restarts
+3. SSHs into the VM, copies config files, writes `.env`, pulls the new image, and restarts containers
 
 ### Rollback
 
@@ -235,13 +227,13 @@ docker compose -f docker-compose.prod.yml up -d
 |----------|----------|-------------|
 | `SPOTIFY_CLIENT_ID` | Yes | From Spotify Developer Dashboard |
 | `POSTGRES_PASSWORD` | Yes | PostgreSQL password |
-| `FRONTEND_URL` | No | CORS origin (defaults to `https://metaloreian.is-a.dev`) |
+| `DUCKDNS_TOKEN` | Yes | DuckDNS token for DNS-01 cert challenges |
+| `FRONTEND_URL` | No | CORS origin (defaults to `https://metaloreian-dev.duckdns.org`) |
 | `PORT` | No | Backend listen port (defaults to `8080`) |
 
 ### Key considerations
 
-- **CORS**: `FRONTEND_URL` must match the domain exactly (`https://metaloreian.is-a.dev`)
-- **Oracle idle VM reclaim**: VMs idle for 7 days (CPU/memory < 20%) may be reclaimed. Chromium usage should keep memory above threshold.
+- **CORS**: `FRONTEND_URL` must match the domain exactly (`https://metaloreian-dev.duckdns.org`)
 - **Database persistence**: The `pgdata` volume survives container restarts. Only `docker compose down -v` destroys it.
 
 ## Notes on Metal Archives integration

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
     environment:
       DATABASE_URL: postgres://metaloreian:${POSTGRES_PASSWORD}@postgres:5432/metaloreian?sslmode=disable
       SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:?Set SPOTIFY_CLIENT_ID in .env}
-      FRONTEND_URL: ${FRONTEND_URL:-https://metaloreian.duckdns.org}
+      FRONTEND_URL: ${FRONTEND_URL:-https://metaloreian-dev.duckdns.org}
       PORT: "8080"
     shm_size: 256m
     healthcheck:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name metaloreian.duckdns.org;
+    server_name metaloreian-dev.duckdns.org;
 
     location / {
         return 301 https://$host$request_uri;
@@ -9,10 +9,10 @@ server {
 
 server {
     listen 443 ssl;
-    server_name metaloreian.duckdns.org;
+    server_name metaloreian-dev.duckdns.org;
 
-    ssl_certificate /etc/letsencrypt/live/metaloreian.duckdns.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/metaloreian.duckdns.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/metaloreian-dev.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/metaloreian-dev.duckdns.org/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';


### PR DESCRIPTION
## Summary
- Update all config files for new AWS EC2 t3.small instance
- Switch domain from `metaloreian.duckdns.org` to `metaloreian-dev.duckdns.org`
- Update deploy workflow to use `~/app/` path and read `FRONTEND_URL` from secrets
- Update README with AWS setup instructions, remove Oracle-specific notes

## Changes
- **nginx.conf**: Domain references updated
- **docker-compose.prod.yml**: Default `FRONTEND_URL` updated
- **deploy.yml**: `~/metaloreian/` → `~/app/`, `FRONTEND_URL` from secrets instead of hardcoded
- **README.md**: Oracle → AWS documentation
- **.gitignore**: Add `CLAUDE.local.md`

## Test plan
- [ ] Merge to main triggers GitHub Actions build
- [ ] Deploy workflow SSHs into EC2 and starts containers
- [ ] SSL certificate obtained via DNS-01 challenge
- [ ] `https://metaloreian-dev.duckdns.org/health` returns 200
- [ ] Spotify OAuth login completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)