### PR TITLE
Fix Cloudflare block on headless Chromium

### DIFF
--- a/backend/internal/scraper/client.go
+++ b/backend/internal/scraper/client.go
@@ -57,6 +57,7 @@ func (c *Client) ensureBrowser() (*rod.Browser, error) {
 		Set("disable-gpu").
 		Set("no-sandbox").
 		Set("disable-dev-shm-usage").
+		Set("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36").
 		MustLaunch()
 
 	browser := rod.New().ControlURL(u)


### PR DESCRIPTION
## Summary
- Set a realistic Chrome user-agent on the headless browser launcher
- Cloudflare blocks the default headless Chrome UA on datacenter IPs (AWS), causing Metal Archives scrapes to time out with 500 errors

## Test plan
- [x] Band search returns results on production (AWS EC2)
- [x] No regression on local development

🤖 Generated with [Claude Code](https://claude.com/claude-code)