### PR TITLE
Fix Docker build cache serving stale layers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,10 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           build-args: |
             VITE_SPOTIFY_CLIENT_ID=${{ vars.VITE_SPOTIFY_CLIENT_ID }}
-          cache-from: type=gha,scope=${{ github.ref_name }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}
+          cache-from: |
+            type=gha,scope=build-${{ github.sha }}
+            type=gha,scope=build-main
+          cache-to: type=gha,mode=max,scope=build-${{ github.sha }}
 
   deploy:
     needs: build-and-push


### PR DESCRIPTION
## Summary
- Scope Docker buildx cache-to by commit SHA instead of branch name
- Prevents reruns from serving stale cached layers
- Falls back to main cache for reads to keep builds fast

This also forces a full rebuild, which will pick up the user-agent fix from PR #14 that was cached out.

## Test plan
- [ ] Merge triggers a fresh Docker build (not fully cached)
- [ ] `strings /app/metaloreian | grep Chrome/131` returns 1 on the deployed container
- [ ] Band detail endpoint (`/api/bands/138`) returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)