### PR TITLE
Add nginx rate limiting and bot scanner blocking

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,5 @@
+limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+
 server {
     listen 80;
     server_name metaloreian-dev.duckdns.org;
@@ -26,6 +28,24 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Block common scanner paths
+    location ~* (\.env|\.git|phpunit|wp-login|wp-admin|/\.well-known/security\.txt) {
+        return 444;
+    }
+
+    # Rate limit API endpoints
+    location /api/ {
+        limit_req zone=api burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
 
     location / {
         proxy_pass http://backend:8080;


### PR DESCRIPTION
## Summary
- Rate limit `/api/` endpoints to 10 requests/second per IP (burst of 20)
- Block common scanner paths (`.env`, `.git`, `phpunit`, `wp-login`, `wp-admin`) with `444` (connection drop)
- Returns `429 Too Many Requests` when rate limit exceeded

## Context
Production logs show constant bot traffic probing for `.env`, phpunit, WordPress admin, and various API framework endpoints. This drops those connections immediately and prevents API abuse.

## Test plan
- [ ] Verify app loads normally after deploy
- [ ] Verify API endpoints work within rate limit
- [ ] Confirm scanner paths return connection reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)